### PR TITLE
Adding support for new Chat completion models

### DIFF
--- a/OpenAI.Tests/ChatCompletionTests.cs
+++ b/OpenAI.Tests/ChatCompletionTests.cs
@@ -40,6 +40,8 @@ public class ChatCompletionTests
     [InlineData(ChatModelType.GPT_4)]
     [InlineData(ChatModelType.GPT_4_VISION_PREVIEW)]
     [InlineData(ChatModelType.GPT_4_1106_PREVIEW)]
+    [InlineData(ChatModelType.GPT_4o)]
+    [InlineData(ChatModelType.GTP_4_TURBO)]
     public void Chat_Models(ChatModelType kind)
     {
         ChatRequest request = new ChatRequestBuilder()
@@ -187,7 +189,7 @@ public class ChatCompletionTests
         Assert.NotNull(_client);
 
         ChatRequest request = new ChatRequestBuilder()
-            .WithModel(ChatModelType.GPT_3_5_TURBO)
+            .WithModel(ChatModelType.GPT_4o)
             .WithSystemMessage("Eres un profesor de alumnos de 10 años.")
             .WithUserMessage("Explícame qué es una estrella.")
             .WithTemperatute(Temperature.Precise)

--- a/OpenAI/Endpoints/Chat/ChatModelType.cs
+++ b/OpenAI/Endpoints/Chat/ChatModelType.cs
@@ -4,10 +4,14 @@ namespace Fitomad.OpenAI.Endpoints.Chat;
 
 public enum ChatModelType
 {
+    GPT_4o,
     GPT_4,
     GPT_4_1106_PREVIEW,
     GPT_4_VISION_PREVIEW,
     GPT_4_32K,
+    GTP_4_TURBO,
+    GPT_4_TURBO_2024_04_09,
+    GPT_4_TURBO_PREVIEW,
     GPT_3_5_TURBO,
     GPT_3_5_TURBO_16K
 }
@@ -18,10 +22,14 @@ public static class ChatModelKindExtension
     {
         var modelName = model switch
         {
+            ChatModelType.GPT_4o => "gpt-4o",
             ChatModelType.GPT_4 => "gpt-4",
             ChatModelType.GPT_4_1106_PREVIEW => "gpt-4-1106-preview",
             ChatModelType.GPT_4_VISION_PREVIEW => "gpt-4-vision-preview",
             ChatModelType.GPT_4_32K => "gpt-4-32k",
+            ChatModelType.GTP_4_TURBO => "gpt-4-turbo",
+            ChatModelType.GPT_4_TURBO_2024_04_09 => "gpt-4-turbo-2024-04-09",
+            ChatModelType.GPT_4_TURBO_PREVIEW => "gpt-4-turbo-preview",
             ChatModelType.GPT_3_5_TURBO => "gpt-3.5-turbo",
             ChatModelType.GPT_3_5_TURBO_16K => "gpt-3.5-turbo-16k",
             _ => "gpt-3.5-turbo"

--- a/OpenAI/OpenAI.csproj
+++ b/OpenAI/OpenAI.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <!-- nuget definition -->
     <PackageId>Fitomad.OpenAI</PackageId>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <Authors>Adolfo Vera</Authors>
     <Company>Fitomad</Company>
     <Description>Fitomad.OpenAI is a .NET library that allows you to access the powerful AI models from OpenAI, such as GPT, DALL-E, and Whisper, through a simple and intuitive interface. You can use Fitomad.OpenAI to generate text, code, images, audio, and more, with just a few lines of code. Fitomad.OpenAI provides various options to customize your requests and responses. Whether you want to create a chatbot, a content generator, a sentiment analyzer, a translator, or any other AI-powered application, Fitomad.OpenAI can help you achieve your goals with ease and efficiency.</Description>

--- a/README.md
+++ b/README.md
@@ -260,6 +260,14 @@ ModelDeletedResponse response = await _client.Models.Delete(model: modelName);
 
 ## Changes
 
+### 1.0.2
+
+- Chat endpoint models brings support the following:
+    - `gpt-4o` 🚀
+    - `gpt-4-turbo`
+    - `gpt-4-turbo-2024-04-09`
+    - `gpt-4-turbo-preview`
+
 ### 0.2.1
 
 - New package icon 🎉


### PR DESCRIPTION
Chat endpoint models brings support the following:
    - `gpt-4o` 🚀
    - `gpt-4-turbo`
    - `gpt-4-turbo-2024-04-09`
    - `gpt-4-turbo-preview`